### PR TITLE
Fix translateAlternateColorCodes for PlaceholderAPI >= 2.11.2

### DIFF
--- a/src/main/java/net/leonardo_dgs/interactivebooks/util/PAPIUtil.java
+++ b/src/main/java/net/leonardo_dgs/interactivebooks/util/PAPIUtil.java
@@ -23,7 +23,7 @@ public final class PAPIUtil {
                 return ChatColor.translateAlternateColorCodes('&',PlaceholderAPI.setPlaceholders(null, text));
             }
         } else {
-            return ChatColor.translateAlternateColorCodes('&',text);
+            return ChatColor.translateAlternateColorCodes('&', text);
         }
     }
 

--- a/src/main/java/net/leonardo_dgs/interactivebooks/util/PAPIUtil.java
+++ b/src/main/java/net/leonardo_dgs/interactivebooks/util/PAPIUtil.java
@@ -18,12 +18,12 @@ public final class PAPIUtil {
     public static String setPlaceholders(CommandSender sender, String text) {
         if (isPlaceholderAPISupported()) {
             if (sender instanceof OfflinePlayer) {
-                return PlaceholderAPI.setPlaceholders((OfflinePlayer) sender, text);
+                return ChatColor.translateAlternateColorCodes('&',PlaceholderAPI.setPlaceholders((OfflinePlayer) sender, text));
             } else {
-                return PlaceholderAPI.setPlaceholders(null, text);
+                return ChatColor.translateAlternateColorCodes('&',PlaceholderAPI.setPlaceholders(null, text));
             }
         } else {
-            return ChatColor.translateAlternateColorCodes('&', text);
+            return ChatColor.translateAlternateColorCodes('&',text);
         }
     }
 


### PR DESCRIPTION
Fix translateAlternateColorCodes for PlaceholderAPI >= 2.11.2


https://www.spigotmc.org/resources/placeholderapi.6245/updates
```
2.11.2

Hey everyone,

Time for the annual PlaceholderAPI update, whilst the last version should work fine with 1.19 this update has been built against the latest version to ensure expansions have access to the latest features. This version also changes how placeholders are parsed in terms of colour, read more below on how this may affect your plugin/expansion.


Changes

Removed colour parsing for placeholder parsing ([#800](http://https//github.com/PlaceholderAPI/PlaceholderAPI/pull/800))
```